### PR TITLE
(feat) Add support of browsersync options

### DIFF
--- a/extensions/browsersync/README.md
+++ b/extensions/browsersync/README.md
@@ -24,6 +24,11 @@ Starts a browserSync Static server with watch mode at `:3000` by default. The UI
 
 > Currently, you can only run one server at a time in the workspace. Starting another server within the workspace will close the current running server and spinup a new one at localhost:3000.
 
+# Options
+Browsersync allows for 2 options:
+1. `openBrowser`: Whether you want to trigger a browser open when server is started.
+2. `options`: Pass browsersync options from https://www.browsersync.io/docs/options
+
 # Development
 
 Clone the repo and `cd` into `browsersync` folder. Run `npm install`, and you are ready for development.

--- a/extensions/browsersync/package.json
+++ b/extensions/browsersync/package.json
@@ -38,6 +38,10 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to open browser on restart or not."
+        },
+        "browsersync.options": {
+          "type": "object",
+          "description": "BrowserSync configuration object, https://www.browsersync.io/docs/options"
         }
       }
     },

--- a/extensions/browsersync/src/extension.ts
+++ b/extensions/browsersync/src/extension.ts
@@ -42,7 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const configuration = vscode.workspace.getConfiguration('browsersync');
     browserSyncServer = browsersync.create();
-    browserSyncServer.init({
+    const defaultConfig = Object.assign({}, configuration.options, {
       serveStatic: [folderPath],
       logLevel: 'silent',
       watchOptions: {
@@ -51,6 +51,8 @@ export function activate(context: vscode.ExtensionContext) {
       },
       files: [folderPath]
     });
+
+    browserSyncServer.init(defaultConfig);
 
     browserSyncServer.emitter.on('service:running', (details) => {
       vscode.window.showInformationMessage(`BrowserSync [with reload] running at ${details.url}`);


### PR DESCRIPTION
Now you can pass `options` for browser sync. 
![image](https://user-images.githubusercontent.com/2890683/52173355-ee30f980-27bd-11e9-9afa-9bd0824c42c9.png)
